### PR TITLE
qualify C_layout and Fortran_layout in bin/tensor_tools.ml

### DIFF
--- a/bin/tensor_tools.ml
+++ b/bin/tensor_tools.ml
@@ -37,8 +37,8 @@ let npz_to_pytorch npz_src pytorch_dst =
       match packed_tensor with
       | Npy.P tensor ->
         match Bigarray.Genarray.layout tensor with
-        | C_layout -> tensor_name, Tensor.of_bigarray tensor
-        | Fortran_layout -> failwith "fortran layout is not supported")
+        | Bigarray.C_layout -> tensor_name, Tensor.of_bigarray tensor
+        | Bigarray.Fortran_layout -> failwith "fortran layout is not supported")
   in
   Serialize.save_multi ~named_tensors ~filename:pytorch_dst
 


### PR DESCRIPTION
I got the following error when building `bin/tensor_tools.ml`:
```
File "bin/tensor_tools.ml", line 40, characters 10-18:
Error: The GADT constructor C_layout of type Bigarray.layout
       must be qualified in this pattern.
```
This is a small fix to make it work.